### PR TITLE
Documentation for paging links

### DIFF
--- a/source/includes/_briefings.md
+++ b/source/includes/_briefings.md
@@ -21,6 +21,10 @@ curl -u username:password \
     "requestedPageSize": 20,
     "totalElementCount": 1
   },
+  "_links": {
+    "first": "https://api.attensa.net/briefings?rows=20&page=0",
+    "last": "https://api.attensa.net/briefings?rows=20&page=0"
+  },
   "briefings": [
     {
       "description": "javascript news",

--- a/source/includes/_categories.md
+++ b/source/includes/_categories.md
@@ -55,6 +55,10 @@ curl -u username:password \
     "requestedPageSize": 20,
     "totalElementCount": 1
   },
+  "_links": {
+    "first": "https://api.attensa.net/categories/{categoryId}/streams?rows=20&term=javascript&type=RSS&published=true&page=0",
+    "last": "https://api.attensa.net/categories/{categoryId}/streams?rows=20&term=javascript&type=RSS&published=true&page=0"
+  },
   "streams": [
     {
       "categoryIds": ["54eba224e4b050dd8b9c1096"],
@@ -127,6 +131,10 @@ curl -u username:password \
     "requestedPageSize": 20,
     "totalElementCount": 1
   },
+  "_links": {
+    "first": "https://api.attensa.net/categories/uncategorized/streams?rows=20&term=javascript&type=RSS&published=true&page=0",
+    "last": "https://api.attensa.net/categories/uncategorized/streams?rows=20&term=javascript&type=RSS&published=true&page=0"
+  },
   "streams": [
     {
       "categoryIds": [],
@@ -195,6 +203,10 @@ curl -u username:password \
     "pageCount": 1,
     "requestedPageSize": 20,
     "totalElementCount": 1
+  },
+  "_links": {
+    "first": "https://api.attensa.net/categories/{categoryId}/briefings?rows=20&page=0",
+    "last": "https://api.attensa.net/categories/{categoryId}/briefings?rows=20&page=0"
   },
   "briefings": [
     {
@@ -273,6 +285,10 @@ curl -u username:password \
     "pageCount": 1,
     "requestedPageSize": 20,
     "totalElementCount": 1
+  },
+  "_links": {
+    "first": "https://api.attensa.net/categories/uncategorized/briefings?rows=20&page=0",
+    "last": "https://api.attensa.net/categories/uncategorized/briefings?rows=20&page=0"
   },
   "briefings": [
     {

--- a/source/includes/_groups.md
+++ b/source/includes/_groups.md
@@ -21,6 +21,10 @@ curl -u username:password \
     "elementCount": 1,
     "page": 0
   },
+  "_links": {
+    "first": "https://api.attensa.net/groups?rows=20&page=0&term=test",
+    "last": "https://api.attensa.net/groups?rows=20&page=0&term=test"
+  },
   "groups": [
     {
       "creatorId": "56161che546097aa51621b47",
@@ -109,6 +113,10 @@ curl -u username:password \
     "elementCount": 1,
     "page": 0
   },
+  "_links": {
+    "first": "https://api.attensa.net/groups/{groupId}/users?rows=20&page=0&term=test&sort=firstName&sortDirection=ASC",
+    "last": "https://api.attensa.net/groups/{groupId}/users?rows=20&page=0&term=test&sort=firstName&sortDirection=ASC"
+  },
   "users": [
     {
       "id": "546e17fcd4c67da2547f5b61",
@@ -171,6 +179,10 @@ curl -u username:password \
     "elementCount": 1,
     "page": 0
   },
+  "_links": {
+    "first": "https://api.attensa.net/groups/{groupId}/streams?rows=20&page=0&term=test",
+    "last": "https://api.attensa.net/groups/{groupId}/streams?rows=20&page=0&term=test"
+  },
   "streams": [{
     "title": "Test Stream 01",
     "groupIsSubscribed": true,
@@ -229,6 +241,10 @@ curl -u username:password \
     "pageCount": 1,
     "requestedPageSize": 20,
     "totalElementCount": 1
+  },
+  "_links": {
+    "first": "https://api.attensa.net/groups/{groupId}/briefings?rows=20&page=0",
+    "last": "https://api.attensa.net/groups/{groupId}/briefings?rows=20&page=0"
   },
   "briefings": [
     {

--- a/source/includes/_paging.md
+++ b/source/includes/_paging.md
@@ -2,16 +2,22 @@
 
 ## Paging format
 
-> Paged responses return a _paging element
+> Paged responses return _paging and _links elements
 
 ```json
 {
   "_paging": {
-    "totalElementCount": 42,
-    "pageCount": 3,
+    "totalElementCount": 82,
+    "pageCount": 5,
     "requestedPageSize": 20,
     "elementCount": 20,
-    "page": 0
+    "page": 2
+  },
+  "_links": {
+    "first": "https://api.attensa.net/users?rows=20&page=0",
+    "last": "https://api.attensa.net/users?rows=20&page=4",
+    "next": "https://api.attensa.net/users?rows=20&page=3",
+    "previous": "https://api.attensa.net/users?rows=20&page=1"
   },
   "users": [
     { "arrayOfUsers": "goes here" }
@@ -19,12 +25,21 @@
 }
 ```
 
-Paged responses will return a `_paging` element with paging metadata as shown to the right. The return data will be named for the type of data being responded to (e.g. requesting users will return a `users` array while requesting streams will return a `streams` array)
+Paged responses will return `_paging` and `_links` elements.
 
-Paging metadata:
+### `_paging` metadata:
 
 * `totalElementCount`: The total number of elements across all pages
 * `pageCount`: The number of pages
 * `requestedPageSize`: The requested page size
 * `elementCount`: The number of elements returned in the current page.  Not that in some cases this may be less than the requested page size due to de-duping rules or filters
 * `page`: The current page number
+
+### `_links` for paging:
+
+* `first`: The first page (page 0) of the current result set
+* `last`: The last page of the current result set
+* `next`: The page immediately after the current page. Omitted if the current page is last.
+* `previous`: The page before the current page. Omitted if the current page is first.
+
+The return data will be named for the type of data being responded to (e.g. requesting users will return a `users` array while requesting streams will return a `streams` array)

--- a/source/includes/_streams.md
+++ b/source/includes/_streams.md
@@ -24,6 +24,10 @@ curl -u username:password \
     "elementCount": 1,
     "page": 0
   },
+  "_links": {
+    "first": "https://api.attensa.net/streams?rows=20&page=0&term=test&type=COLLECTION&published=true",
+    "last": "https://api.attensa.net/streams?rows=20&page=0&term=test&type=COLLECTION&published=true"
+  },
   "streams": [{
     "id": "546e17fcd4c67da2547f5b61",
     "title": "Test Stream 01",

--- a/source/includes/_users.md
+++ b/source/includes/_users.md
@@ -193,6 +193,10 @@ curl -u username:password \
     "requestedPageSize": 20,
     "totalElementCount": 1
   },
+  "_links": {
+    "first": "https://api.attensa.net/users/{userId}/briefings?rows=20&page=0",
+    "last": "https://api.attensa.net/users/{userId}/briefings?rows=20&page=0"
+  },
   "briefings": [
     {
       "subject": "My email subject line!",


### PR DESCRIPTION
Adds documentation for the `_links` element returned with paged responses that is implemented in https://github.com/Attensadev/customer-api/pull/80.  

This should deploy concurrently with that PR.

[#100991978](https://www.pivotaltracker.com/story/show/100991978)