### PR TITLE
DOCS - Enumerate stream types and add clinicaltrials/factiva support

### DIFF
--- a/source/includes/_categories.md
+++ b/source/includes/_categories.md
@@ -107,7 +107,7 @@ page | The page number to retrieve | No | Integer | 0
 published | Filter stream list to published or unpublished streams. Omit for all streams. | No | Boolean | `null`
 rows | Number of streams in each page | No | Integer | 20
 term | A search term to narrow the list of streams returned | No | String | `null`
-type | Filter results to a specific stream type | No | `ATTENSA_SEARCH`, `COLLECTION`, `PUBMED_SEARCH`, `RSS`, `TWITTER_SEARCH`, `XML` | `null`
+type | Filter results to a specific stream type | No | [searchable stream type](#stream-types) | `null`
 
 ### Response
 
@@ -185,7 +185,7 @@ page | The page number to retrieve | No | Integer | 0
 published | Filter stream list to published or unpublished streams. Omit for all streams. | No | Boolean | `null`
 rows | Number of streams in each page | No | Integer | 20
 term | A search term to narrow the list of streams returned | No | String | `null`
-type | Filter results to a specific stream type | No | `ATTENSA_SEARCH`, `COLLECTION`, `PUBMED_SEARCH`, `RSS`, `TWITTER_SEARCH`, `XML` | `null`
+type | Filter results to a specific stream type | No | [searchable stream type](#stream-types) | `null`
 
 ### Response
 

--- a/source/includes/_streamTags.md
+++ b/source/includes/_streamTags.md
@@ -97,7 +97,7 @@ page | The page number to retrieve | No | Integer | 0
 published | Filter stream list to published or unpublished streams. Omit for all streams. | No | Boolean | `null`
 rows | Number of users in each page | No | Integer | 20
 term | A search term to narrow the list of streams returned | No | String | `null`
-type | Filter results to a specific stream type | No | `ATTENSA_SEARCH`, `COLLECTION`, `PUBMED_SEARCH`, `RSS`, `TWITTER_SEARCH`, `XML` | `null`
+type | Filter results to a specific stream type | No | [searchable stream type](#stream-types) | `null`
 
 ### Response
 

--- a/source/includes/_streams.md
+++ b/source/includes/_streams.md
@@ -1,5 +1,19 @@
 # Streams
 
+## Stream Types
+
+Attensa supports the following stream types
+
+Type | Description | Can create | Can search
+--------- | ----------- | -------- | ------ | -------
+COLLECTION | A combination stream composed of items from other streams | Yes | Yes
+RSS | Content from an RSS feed | Yes | Yes
+ATTENSA_SEARCH | Composed based on a search of items in other streams in Attensa | Yes | Yes
+TWITTER_SEARCH | Content based on a twitter search | Yes | Yes
+PUBMED_SEARCH | Content from PubMed | Yes | Yes
+CLINICALTRIALS_SEARCH | Content from clinicaltrials.gov | Yes | Yes
+FACTIVA_SELECT_HTTP | Content from a Factiva Select feed | No | Yes
+
 ## GET /streams
 
 ```shell
@@ -72,7 +86,7 @@ page | The page number to retrieve | No | Integer | 0
 published | Filter stream list to published or unpublished streams. Omit for all streams. | No | Boolean | `null`
 rows | Number of streams in each page | No | Integer | 20
 term | A search term to narrow the list of streams returned | No | String | `null`
-type | Filter results to a specific stream type | No | `ATTENSA_SEARCH`, `COLLECTION`, `PUBMED_SEARCH`, `RSS`, `TWITTER_SEARCH`, `XML` | `null`
+type | Filter results to a specific stream type | No | [searchable stream type](#stream-types) | `null`
 
 ### Response
 
@@ -256,7 +270,7 @@ Parameter | Description | Required | Format | Default
 title | Stream Title | Yes | String | n/a
 description | Stream description | No | String | `null`
 ownerId | User id of stream owner | Yes | String of valid user id | n/a
-type | Stream type | Yes | `ATTENSA_SEARCH`, `COLLECTION`, `PUBMED_SEARCH`, `RSS`, `TWITTER_SEARCH` | n/a
+type | Stream type | Yes | [creatable stream type](#stream-types) | n/a
 source:search | Search term. Only supply for ATTENSA_SEARCH, PUBMED_SEARCH or TWITTER_SEARCH streams | For type ATTENSA_SEARCH, PUBMED_SEARCH, TWITTER_SEARCH | String | `null`
 source:uri | Uri of rss feed. Only supply for type RSS streams | For type RSS | String | `null`
 source:username | Basic auth username for secured rss feed. Only supply for type RSS streams. | For secured RSS streams | String | `null`


### PR DESCRIPTION
* Adds a section to enumerate stream types.
* Adds support for clinical trials and factiva stream types.

This should deploy concurrently with https://github.com/Attensadev/customer-api/pull/100

[#102171908](https://www.pivotaltracker.com/story/show/102171908)