### PR TITLE
Documentation for DELETE /streams/{streamId}/briefing

### DIFF
--- a/source/includes/_streams.md
+++ b/source/includes/_streams.md
@@ -562,6 +562,25 @@ Delete an existing stream from the system.  All users will be un-followed and un
 
 Status code `204` with empty body
 
+## DELETE /streams/{streamId}/briefing
+
+```shell
+curl -u username:password \
+     -X DELETE \
+     https://api.attensa.net/streams/{streamId}/briefing
+```
+> 204 empty body returned on success
+
+Remove a briefing from a stream
+
+### Request
+
+`DELETE https://api.attensa.net/streams/{streamId}/streams/{substreamId}`
+
+### Response
+
+Status code `204` with empty body
+
 ## DELETE /streams/{streamId}/streams/{substreamId}
 
 ```shell
@@ -569,7 +588,7 @@ curl -u username:password \
      -X DELETE \
      https://api.attensa.net/streams/{streamId}/streams/{substreamId}
 ```
-> 204 emtpy body returned on success
+> 204 empty body returned on success
 
 Remove a substream from an existing COLLECTION stream.
 


### PR DESCRIPTION
Adds documentation for DELETE /streams/{streamId}/briefing.  This endpoint removes a briefing from a stream.

[#103624168 - Add support for DELETE /streams/{streamId}/briefing](https://www.pivotaltracker.com/story/show/103624168)